### PR TITLE
refactor(mixins): Remove unnecessary dependency (mixins)

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,14 +46,14 @@
     "csv": "^1.1.0",
     "debug": "2.2.0",
     "optimist": "0.6.1",
-    "sphere-node-sdk": "^1.16.2",
+    "sphere-node-sdk": "1.17.5",
     "sphere-node-utils": "0.7.0",
     "tmp": "0.0.23",
     "underscore": "1.8.3",
-    "underscore-mixins": "*",
     "xml2js": "0.4.9"
   },
   "devDependencies": {
+    "coffee-script": "^1.12.3",
     "coveralls": "2.11.2",
     "grunt": "0.4.5",
     "grunt-bump": "0.0.13",

--- a/src/coffee/mappings.coffee
+++ b/src/coffee/mappings.coffee
@@ -1,5 +1,4 @@
 _ = require 'underscore'
-_.mixin require('underscore-mixins')
 csv = require 'csv'
 CONS = require './constants'
 

--- a/src/coffee/stockimport.coffee
+++ b/src/coffee/stockimport.coffee
@@ -287,7 +287,13 @@ class StockImport
       @_processBatches(stocks)
 
   _processBatches: (stocks) ->
-    batchedList = _.batchList(stocks, 30) # max parallel elem to process
+    batchedList = stocks.reduce(batch, value, index) ->
+      if index % size == 30 then batch.push []
+
+      batch[batch.length - 1].push value
+      batch
+    , []
+
     Promise.map batchedList, (stocksToProcess) =>
       debug 'Chunk: %j', stocksToProcess
       uniqueStocksToProcessBySku = @_uniqueStocksBySku(stocksToProcess)

--- a/src/spec/elasticio.spec.coffee
+++ b/src/spec/elasticio.spec.coffee
@@ -1,5 +1,4 @@
 _ = require 'underscore'
-_.mixin require('underscore-mixins')
 Promise = require 'bluebird'
 {SphereClient} = require 'sphere-node-sdk'
 {ExtendedLogger, ElasticIo} = require 'sphere-node-utils'
@@ -33,14 +32,14 @@ describe 'elasticio integration', ->
     @logger.info 'About to setup...'
     cleanup(@logger, @client)
     .then -> done()
-    .catch (err) -> done(_.prettify err)
+    .catch (err) -> done(err)
   , 10000 # 10sec
 
   afterEach (done) ->
     @logger.info 'About to cleanup...'
     cleanup(@logger, @client)
     .then -> done()
-    .catch (err) -> done(_.prettify err)
+    .catch (err) -> done(err)
   , 10000 # 10sec
 
   it 'should work with no attachments nor body', (done) ->

--- a/src/spec/integration.spec.coffee
+++ b/src/spec/integration.spec.coffee
@@ -1,5 +1,4 @@
 _ = require 'underscore'
-_.mixin require('underscore-mixins')
 Promise = require 'bluebird'
 {ExtendedLogger} = require 'sphere-node-utils'
 package_json = require '../package.json'
@@ -53,14 +52,14 @@ describe 'integration test', ->
     cleanup(@logger, @client)
     .then =>
       done()
-    .catch (err) -> done(_.prettify err)
+    .catch (err) -> done(err)
   , 10000 # 10sec
 
   afterEach (done) ->
     @logger.info 'About to cleanup...'
     cleanup(@logger, @client)
     .then -> done()
-    .catch (err) -> done(_.prettify err)
+    .catch (err) -> done(err)
   , 10000 # 10sec
 
   describe 'XML file', ->
@@ -71,7 +70,7 @@ describe 'integration test', ->
       .then (message) ->
         expect(message).toBe 'Summary: nothing to do, everything is fine'
         done()
-      .catch (err) -> done(_.prettify err)
+      .catch (err) -> done(err)
     , 10000 # 10sec
 
     it 'one new stock', (done) ->
@@ -105,7 +104,7 @@ describe 'integration test', ->
         expect(stocks[0].sku).toBe '123'
         expect(stocks[0].quantityOnStock).toBe 2
         done()
-      .catch (err) -> done(_.prettify err)
+      .catch (err) -> done(err)
     , 10000 # 10sec
 
     it 'add more stock', (done) ->
@@ -140,7 +139,7 @@ describe 'integration test', ->
         expect(stocks[0].sku).toBe '234'
         expect(stocks[0].quantityOnStock).toBe 19
         done()
-      .catch (err) -> done(_.prettify err)
+      .catch (err) -> done(err)
     , 10000 # 10sec
 
     it 'remove some stock', (done) ->
@@ -175,7 +174,7 @@ describe 'integration test', ->
         expect(stocks[0].sku).toBe '1234567890'
         expect(stocks[0].quantityOnStock).toBe -13
         done()
-      .catch (err) -> done(_.prettify err)
+      .catch (err) -> done(err)
     , 10000 # 10sec
 
     it 'should create and update 2 stock entries when appointed quantity is given', (done) ->
@@ -301,7 +300,7 @@ describe 'integration test', ->
         expect(stockB.expectedDelivery).toBeUndefined()
 
         done()
-      .catch (err) -> done(_.prettify err)
+      .catch (err) -> done(err)
     , 20000 # 20sec
 
   describe 'CSV file', ->
@@ -334,7 +333,7 @@ describe 'integration test', ->
         expect(stocks[0].sku).toBe 'abcd'
         expect(stocks[0].quantityOnStock).toBe 0
         done()
-      .catch (err) -> done(_.prettify err)
+      .catch (err) -> done(err)
     , 10000 # 10sec
 
   describe 'CSV file', =>
@@ -361,14 +360,14 @@ describe 'integration test', ->
         @client.channels.create(key: 'testchannel2').then (result) ->
           testChannel2 = result.body
           done()
-      .catch (err) -> done(_.prettify err)
+      .catch (err) -> done(err)
     , 10000 # 10sec
 
     afterEach (done) ->
       @logger.info 'About to cleanup...'
       cleanup(@logger, @client)
       .then -> done()
-      .catch (err) -> done(_.prettify err)
+      .catch (err) -> done(err)
     , 10000 # 10sec
 
     it 'CSV - one new stock', (done) ->
@@ -400,7 +399,7 @@ describe 'integration test', ->
         expect(stocks[0].quantityOnStock).toBe 77
         done()
       .catch (err) ->
-        done(_.prettify err)
+        done(err)
     , 10000 # 10sec
 
     it 'CSV - should ignore empty fields in customFields', (done) ->
@@ -442,7 +441,7 @@ describe 'integration test', ->
         done()
       .catch (err) ->
         console.log JSON.stringify(err, null,2)
-        done(_.prettify err)
+        done(err)
     , 10000 # 10sec
 
     it 'CSV - update stock', (done) ->
@@ -481,7 +480,7 @@ describe 'integration test', ->
         expect(stocks[0].custom.fields.color).toBe 'blue'
         done()
       .catch (err) ->
-        done(_.prettify err)
+        done(err)
     , 10000 # 10sec
 
     it 'CSV - API should return error if required header is missing', (done) ->

--- a/src/spec/stockimport.spec.coffee
+++ b/src/spec/stockimport.spec.coffee
@@ -1,5 +1,4 @@
 _ = require 'underscore'
-_.mixin require('underscore-mixins')
 Promise = require 'bluebird'
 csv = require 'csv'
 sinon = require 'sinon'
@@ -467,7 +466,7 @@ describe 'StockImport', ->
         .then (result) =>
           expect(@import._mapStockFromCSV).toHaveBeenCalledWith [ [ '123', '77' ], [ 'abc', '-3' ] ], [ 'sku', 'quantityOnStock' ]
           done()
-        .catch (err) -> done(_.prettify err)
+        .catch (err) -> done(err)
 
 
   describe '::performStream', ->
@@ -475,7 +474,7 @@ describe 'StockImport', ->
     it 'should execute callback after finished processing batches', (done) ->
       spyOn(@import, '_processBatches').andCallFake -> Promise.resolve()
       @import.performStream [1, 2, 3], done
-      .catch (err) -> done(_.prettify err)
+      .catch (err) -> done(err)
 
 
   describe '::_processBatches', ->
@@ -502,7 +501,7 @@ describe 'StockImport', ->
           created: 1
           updated: 1
         done()
-      .catch (err) -> done(_.prettify err)
+      .catch (err) -> done(err)
 
 
   describe '::_createOrUpdate', ->
@@ -533,7 +532,7 @@ describe 'StockImport', ->
         expect(@import.client._rest.POST.calls[0].args[1]).toEqual expectedUpdate
         expect(@import.client._rest.POST.calls[1].args[1]).toEqual expectedCreate
         done()
-      .catch (err) -> done(_.prettify err)
+      .catch (err) -> done(err)
 
 
   describe '::_match', ->


### PR DESCRIPTION
__block by__ https://github.com/sphereio/sphere-node-sdk/pull/212
This removes `underscore-mixins` as a dependency, since it is rarely used.

This has been discussed with @Siilwyn 