### PR TITLE
feat(stock-import): add repeater on 409 errors (#66)

### DIFF
--- a/src/coffee/stockimport.coffee
+++ b/src/coffee/stockimport.coffee
@@ -355,7 +355,7 @@ class StockImport
         @client.inventoryEntries.create(entry)
 
     debug 'About to send %s requests', _.size(posts)
-    Promise.map(posts, (p) -> p)
+    Promise.all(posts)
 
   _updateInventory: (entry, existingEntry, tryCount = 1) =>
     synced = @sync.buildActions(entry, existingEntry)

--- a/src/coffee/stockimport.coffee
+++ b/src/coffee/stockimport.coffee
@@ -372,9 +372,9 @@ class StockImport
             .then (result) =>
               @_updateInventory(entry, result.body, tryCount + 1)
           else
-            Promise.reject "Retry limit #{max409Retries} reached for stock #{JSON.stringify(entry)}"
+            Promise.reject new Error("Retry limit #{max409Retries} reached for stock #{JSON.stringify(entry)}")
         else
-          Promise.reject "Unexpected error when updating stock #{JSON.stringify(entry)}: #{JSON.stringify(err)}"
+          Promise.reject err
     else
       Promise.resolve statusCode: 304
 

--- a/src/spec/stockimport.spec.coffee
+++ b/src/spec/stockimport.spec.coffee
@@ -552,7 +552,7 @@ describe 'StockImport', ->
       .then =>
         done('Test should fail')
       .catch () ->
-        methodCalledCounter == 9
+        expect(methodCalledCounter).toEqual(11)
         done()
 
 


### PR DESCRIPTION
#### Summary
Stock import should repeat on concurrency modification error (409). It should refetch the inventory and recreate the action.

Fixes: https://github.com/sphereio/sphere-stock-import/issues/66