### PR TITLE
fix(sphere-stock-import): Add sphere error message in case of 409 err…

### DIFF
--- a/src/coffee/stockimport.coffee
+++ b/src/coffee/stockimport.coffee
@@ -384,6 +384,8 @@ class StockImport
                 Promise.reject err
           else
             debug "Failed to retry the task after #{@max409Retries} attempts for stock #{JSON.stringify(entry)}"
+            customMessage = "Failed to retry the task after #{@max409Retries} attempts for stock #{JSON.stringify(entry)}"
+            err.sphereStockImportErrMessage = customMessage
             Promise.reject err
         else if (err.statusCode == 404)
           debug "It seems that stock update has conflicted with parallel stock deletion "

--- a/src/coffee/stockimport.coffee
+++ b/src/coffee/stockimport.coffee
@@ -383,8 +383,8 @@ class StockImport
                 debug "Error on handling 409 stock update error. Details: #{JSON.stringify(err)}"
                 Promise.reject err
           else
-            debug "Failed to retry the task after #{@max409Retries} attempts for stock #{JSON.stringify(entry)}"
             customMessage = "Failed to retry the task after #{@max409Retries} attempts for stock #{JSON.stringify(entry)}"
+            debug customMessage
             err.sphereStockImportErrMessage = customMessage
             Promise.reject err
         else if (err.statusCode == 404)


### PR DESCRIPTION
### Summary
Add sphere error message in case of 409 error in stock import

#### Description
In stock import process when SDK returns 409 error importer retries a request 10 times and then rejects without a custom error message. 

closes #78 