### PR TITLE
chore(travis-CI): add node v8 to CI and remove v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ services:
   - docker
 language: node_js
 node_js:
-  - 4
   - 6
+  - 8
 branches:
   except:
     - latest

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "main": "lib/stockimport",
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 6.0.0"
   },
   "scripts": {
     "build": "grunt build",


### PR DESCRIPTION
#### Summary
Add node v8 to CI and remove v4

#### Description

- Add of node v8 to CI and remove v4 in sphere-stock-import

- Change of engine from node ">= 0.10.0" to ">= 6.0.0" in package.json

Part of [this issue](https://github.com/commercetools/nodejs-tasks-board/issues/10)