### PR TITLE
chore: add keyword for automation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sphere-stock-import",
-  "description": "Import your stock information into SPHERE.IO's inventory from CSV or XML, with SFTP support!",
+  "description": "Import stock information into commercetools' inventory from CSV or XML, with SFTP support!",
   "version": "2.0.0",
   "homepage": "https://github.com/sphereio/sphere-stock-import",
   "private": false,
@@ -76,6 +76,7 @@
     "import",
     "csv",
     "xml",
-    "sftp"
+    "sftp",
+    "cli"
   ]
 }


### PR DESCRIPTION
Adds the cli keyword to packages used by IMPEX to enable automation of the "CLI Overview" page on the docs site. See DOCS-44 for more information.

It also fixes a few grammar issues in the descriptions, since those are getting pulled in too ;)

cc: @daern91, @Babanila 

#### Summary
<!-- Provide a short summary of your changes -->

#### Description
<!-- Describe the changes in this PR here and provide some context -->

#### Todo

- Tests
    - [ ] Unit
    - [ ] Integration
    - [ ] Acceptance
- [ ] Documentation
<!-- Two persons should review a PR, don't forget to assign them. -->
