### PR TITLE
feat(stockImport): add a possibility to remove zero inventories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sphere-stock-import",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/coffee/run.coffee
+++ b/src/coffee/run.coffee
@@ -65,10 +65,10 @@ process.on 'SIGUSR2', -> logger.reopenFileStreams()
 process.on 'exit', => process.exit(@exitCode)
 
 removeZeroInventories = (importer, logger) ->
-  logger.info("Deleting zero inventories")
+  logger.info("Deleting inventories with zero quantity on stock")
   importer.removeZeroInventories()
     .then (removedInventoriesCount) ->
-      logger.info "Removed #{removedInventoriesCount} zero inventories"
+      logger.info "Removed #{removedInventoriesCount} inventories with zero quantity on stock"
 
 importFn = (importer, fileName) ->
   throw new Error 'You must provide a file to be processed' unless fileName

--- a/src/coffee/run.coffee
+++ b/src/coffee/run.coffee
@@ -20,6 +20,7 @@ argv = require('optimist')
   .describe('sphereAuthProtocol', 'SPHERE.IO OAuth protocol to connect to')
   .describe('file', 'XML or CSV file containing inventory information to import')
   .describe('csvDelimiter', 'the delimiter type used in the csv')
+  .describe('removeZeroInventories', 'Remove inventory entries where the quantityOnStock equals to zero')
   .describe('sftpCredentials', 'the path to a JSON file where to read the credentials from')
   .describe('sftpHost', 'the SFTP host (overwrite value in sftpCredentials JSON, if given)')
   .describe('sftpUsername', 'the SFTP username (overwrite value in sftpCredentials JSON, if given)')
@@ -35,6 +36,7 @@ argv = require('optimist')
   .describe('logSilent', 'use console to print messages')
   .describe('timeout', 'Set timeout for requests')
   .default('csvDelimiter', ',')
+  .default('removeZeroInventories', false)
   .default('logLevel', 'info')
   .default('logDir', '.')
   .default('logSilent', false)
@@ -61,6 +63,12 @@ if argv.logSilent
 
 process.on 'SIGUSR2', -> logger.reopenFileStreams()
 process.on 'exit', => process.exit(@exitCode)
+
+removeZeroInventories = (importer, logger) ->
+  logger.info("Deleting zero inventories")
+  importer.removeZeroInventories()
+    .then (removedInventoriesCount) ->
+      logger.info "Removed #{removedInventoriesCount} zero inventories"
 
 importFn = (importer, fileName) ->
   throw new Error 'You must provide a file to be processed' unless fileName
@@ -98,6 +106,7 @@ ensureCredentials = (argv) ->
 ensureCredentials(argv)
 .then (credentials) =>
   options = _.extend credentials,
+    removeZeroInventories: argv.removeZeroInventories
     timeout: argv.timeout
     user_agent: "#{package_json.name} - #{package_json.version}"
     csvDelimiter: argv.csvDelimiter
@@ -115,6 +124,9 @@ ensureCredentials(argv)
 
   if file
     importFn(stockimport, file)
+    .then =>
+      if argv.removeZeroInventories
+        removeZeroInventories(stockimport, logger)
     .then => @exitCode = 0
     .catch (error) =>
       logger.error error, 'Oops, something went wrong when processing file (no SFTP)!'
@@ -168,7 +180,6 @@ ensureCredentials(argv)
                   else file
               else
                 filename = file
-
               logger.debug "Finishing processing file #{file}"
               sftpHelper.finish(file, filename)
               .then ->
@@ -182,6 +193,9 @@ ensureCredentials(argv)
               else
                 Promise.reject err
           , {concurrency: 1}
+          .then =>
+            if argv.removeZeroInventories
+              removeZeroInventories(stockimport, logger)
           .then =>
             totFiles = _.size(filesToProcess)
             if totFiles > 0

--- a/src/spec/elasticio.spec.coffee
+++ b/src/spec/elasticio.spec.coffee
@@ -153,11 +153,11 @@ describe 'elasticio integration', ->
 
       elasticio.process msg, cfg, (error, message) ->
         expect(error).toBe null
-        expect(message).toBe 'Summary: there were 1 imported stocks (1 were new and 0 were updates)'
+        expect(message).toBe 'Summary: there were 1 imported stocks (1 were new, 0 were updates)'
         msg.body.QUANTITY = '3'
         elasticio.process msg, cfg, (error, message) ->
           expect(error).toBe null
-          expect(message).toBe 'Summary: there were 1 imported stocks (0 were new and 1 were updates)'
+          expect(message).toBe 'Summary: there were 1 imported stocks (0 were new, 1 were updates)'
           elasticio.process msg, cfg, (error, message) ->
             expect(error).toBe null
             expect(message).toBe 'Summary: nothing to do, everything is fine'
@@ -179,11 +179,11 @@ describe 'elasticio integration', ->
 
       elasticio.process msg, cfg, (error, message) ->
         expect(error).toBe null
-        expect(message).toBe 'Summary: there were 1 imported stocks (1 were new and 0 were updates)'
+        expect(message).toBe 'Summary: there were 1 imported stocks (1 were new, 0 were updates)'
         msg.body.QUANTITY = '3'
         elasticio.process msg, cfg, (error, message) ->
           expect(error).toBe null
-          expect(message).toBe 'Summary: there were 1 imported stocks (0 were new and 1 were updates)'
+          expect(message).toBe 'Summary: there were 1 imported stocks (0 were new, 1 were updates)'
           done()
     , 10000 # 10sec
 
@@ -204,10 +204,10 @@ describe 'elasticio integration', ->
 
         elasticio.process msg, cfg, (error, message) ->
           expect(error).toBe null
-          expect(message).toBe 'Summary: there were 1 imported stocks (1 were new and 0 were updates)'
+          expect(message).toBe 'Summary: there were 1 imported stocks (1 were new, 0 were updates)'
           msg.body.QUANTITY = '3'
           elasticio.process msg, cfg, (error, message) ->
             expect(error).toBe null
-            expect(message).toBe 'Summary: there were 1 imported stocks (0 were new and 1 were updates)'
+            expect(message).toBe 'Summary: there were 1 imported stocks (0 were new, 1 were updates)'
             done()
     , 10000 # 10sec

--- a/src/spec/integration.spec.coffee
+++ b/src/spec/integration.spec.coffee
@@ -1,34 +1,10 @@
 _ = require 'underscore'
-Promise = require 'bluebird'
 {ExtendedLogger} = require 'sphere-node-utils'
 package_json = require '../package.json'
 Config = require '../config'
 StockImport = require '../lib/stockimport'
 {customTypePayload1, customTypePayload2, customTypePayload3} = require './helper-customTypePayload.spec'
-
-cleanup = (logger, client) ->
-  logger.debug 'Deleting old inventory entries...'
-  client.inventoryEntries.all().fetch()
-  .then (result) ->
-    Promise.all _.map result.body.results, (e) ->
-      client.inventoryEntries.byId(e.id).delete(e.version)
-  .then (results) ->
-    logger.debug "Inventory #{_.size results} deleted."
-    logger.debug 'Deleting old types entries...'
-    client.types.all().fetch()
-  .then (result) ->
-    Promise.all _.map result.body.results, (e) ->
-      client.types.byId(e.id).delete(e.version)
-  .then (results) ->
-    logger.debug "Types #{_.size results} deleted."
-    logger.debug 'Deleting old channels entries...'
-    client.channels.all().fetch()
-  .then (result) ->
-    Promise.all _.map result.body.results, (e) ->
-      client.channels.byId(e.id).delete(e.version)
-  .then (results) ->
-    logger.debug "Channels #{_.size results} deleted."
-    Promise.resolve()
+{ cleanup } = require './utils.spec'
 
 describe 'integration test', ->
 
@@ -86,7 +62,7 @@ describe 'integration test', ->
       @stockimport.run(rawXml, 'XML')
       .then => @stockimport.summaryReport()
       .then (message) =>
-        expect(message).toBe 'Summary: there were 1 imported stocks (1 were new and 0 were updates)'
+        expect(message).toBe 'Summary: there were 1 imported stocks (1 were new, 0 were updates)'
         @client.inventoryEntries.fetch()
       .then (result) =>
         stocks = result.body.results
@@ -121,7 +97,7 @@ describe 'integration test', ->
       @stockimport.run(rawXml, 'XML')
       .then => @stockimport.summaryReport()
       .then (message) =>
-        expect(message).toBe 'Summary: there were 1 imported stocks (1 were new and 0 were updates)'
+        expect(message).toBe 'Summary: there were 1 imported stocks (1 were new, 0 were updates)'
         @client.inventoryEntries.fetch()
       .then (result) =>
         stocks = result.body.results
@@ -131,7 +107,7 @@ describe 'integration test', ->
         @stockimport.run(rawXmlChanged, 'XML')
       .then => @stockimport.summaryReport()
       .then (message) =>
-        expect(message).toBe 'Summary: there were 1 imported stocks (0 were new and 1 were updates)'
+        expect(message).toBe 'Summary: there were 1 imported stocks (0 were new, 1 were updates)'
         @client.inventoryEntries.fetch()
       .then (result) ->
         stocks = result.body.results
@@ -156,7 +132,7 @@ describe 'integration test', ->
       @stockimport.run(rawXml, 'XML')
       .then => @stockimport.summaryReport()
       .then (message) =>
-        expect(message).toBe 'Summary: there were 1 imported stocks (1 were new and 0 were updates)'
+        expect(message).toBe 'Summary: there were 1 imported stocks (1 were new, 0 were updates)'
         @client.inventoryEntries.fetch()
       .then (result) =>
         stocks = result.body.results
@@ -166,7 +142,7 @@ describe 'integration test', ->
         @stockimport.run(rawXmlChanged, 'XML')
       .then => @stockimport.summaryReport()
       .then (message) =>
-        expect(message).toBe 'Summary: there were 1 imported stocks (0 were new and 1 were updates)'
+        expect(message).toBe 'Summary: there were 1 imported stocks (0 were new, 1 were updates)'
         @client.inventoryEntries.fetch()
       .then (result) ->
         stocks = result.body.results
@@ -196,7 +172,7 @@ describe 'integration test', ->
       @stockimport.run(rawXml, 'XML')
       .then => @stockimport.summaryReport()
       .then (message) =>
-        expect(message).toBe 'Summary: there were 2 imported stocks (2 were new and 0 were updates)'
+        expect(message).toBe 'Summary: there were 2 imported stocks (2 were new, 0 were updates)'
         @client.inventoryEntries.sort('id').fetch()
       .then (result) =>
         stocks = result.body.results
@@ -218,7 +194,7 @@ describe 'integration test', ->
         @stockimport.run(rawXmlChangedAppointedQuantity, 'XML')
       .then => @stockimport.summaryReport()
       .then (message) =>
-        expect(message).toBe 'Summary: there were 1 imported stocks (0 were new and 1 were updates)'
+        expect(message).toBe 'Summary: there were 1 imported stocks (0 were new, 1 were updates)'
         @client.inventoryEntries.sort('id').fetch()
       .then (result) =>
         stocks = result.body.results
@@ -239,7 +215,7 @@ describe 'integration test', ->
         @stockimport.run(rawXmlChangedCommittedDeliveryDate, 'XML')
       .then => @stockimport.summaryReport()
       .then (message) =>
-        expect(message).toBe 'Summary: there were 1 imported stocks (0 were new and 1 were updates)'
+        expect(message).toBe 'Summary: there were 1 imported stocks (0 were new, 1 were updates)'
         @client.inventoryEntries.sort('id').fetch()
       .then (result) =>
         stocks = result.body.results
@@ -281,7 +257,7 @@ describe 'integration test', ->
         @stockimport.run(rawXmlEmptyValues, 'XML')
       .then => @stockimport.summaryReport()
       .then (message) =>
-        expect(message).toBe 'Summary: there were 1 imported stocks (0 were new and 1 were updates)'
+        expect(message).toBe 'Summary: there were 1 imported stocks (0 were new, 1 were updates)'
         @client.inventoryEntries.sort('id').fetch()
       .then (result) ->
         stocks = result.body.results
@@ -315,7 +291,7 @@ describe 'integration test', ->
       .then =>
         @stockimport.summaryReport()
       .then (message) =>
-        expect(message).toBe 'Summary: there were 1 imported stocks (1 were new and 0 were updates)'
+        expect(message).toBe 'Summary: there were 1 imported stocks (1 were new, 0 were updates)'
         @client.inventoryEntries.fetch()
       .then (result) =>
         stocks = result.body.results
@@ -413,7 +389,7 @@ describe 'integration test', ->
       .then =>
         @stockimport.summaryReport()
       .then (message) =>
-        expect(message).toBe 'Summary: there were 1 imported stocks (1 were new and 0 were updates)'
+        expect(message).toBe 'Summary: there were 1 imported stocks (1 were new, 0 were updates)'
         @client.inventoryEntries.fetch()
       .then (result) =>
         stocks = result.body.results
@@ -447,7 +423,7 @@ describe 'integration test', ->
       .then =>
         @stockimport.summaryReport()
       .then (message) =>
-        expect(message).toBe 'Summary: there were 2 imported stocks (2 were new and 0 were updates)'
+        expect(message).toBe 'Summary: there were 2 imported stocks (2 were new, 0 were updates)'
         @client.inventoryEntries.fetch()
       .then (result) =>
         stocks = result.body.results
@@ -492,7 +468,7 @@ describe 'integration test', ->
       .then =>
         @stockimport.summaryReport()
       .then (message) =>
-        expect(message).toBe 'Summary: there were 1 imported stocks (1 were new and 0 were updates)'
+        expect(message).toBe 'Summary: there were 1 imported stocks (1 were new, 0 were updates)'
         @client.inventoryEntries.fetch()
       .then (result) =>
         stocks = result.body.results
@@ -502,7 +478,7 @@ describe 'integration test', ->
         @stockimport.run(raw2, 'CSV')
       .then => @stockimport.summaryReport()
       .then (message) =>
-        expect(message).toBe 'Summary: there were 1 imported stocks (0 were new and 1 were updates)'
+        expect(message).toBe 'Summary: there were 1 imported stocks (0 were new, 1 were updates)'
         @client.inventoryEntries.fetch()
       .then (result) ->
         stocks = result.body.results
@@ -526,7 +502,7 @@ describe 'integration test', ->
       .then =>
         @stockimport.summaryReport()
       .then (message) =>
-        expect(message).toBe 'Summary: there were 1 imported stocks (1 were new and 0 were updates)'
+        expect(message).toBe 'Summary: there were 1 imported stocks (1 were new, 0 were updates)'
         @client.inventoryEntries.fetch()
       .then (result) =>
         stocks = result.body.results

--- a/src/spec/stockimport.spec.coffee
+++ b/src/spec/stockimport.spec.coffee
@@ -48,7 +48,7 @@ describe 'StockImport', ->
         emptySKU: 2
         created: 5
         updated: 10
-      message = 'Summary: there were 15 imported stocks (5 were new and 10 were updates)' +
+      message = 'Summary: there were 15 imported stocks (5 were new, 10 were updates)' +
        '\nFound 2 empty SKUs from file input \'./foo.json\''
       expect(@import.summaryReport('./foo.json')).toEqual message
 

--- a/src/spec/utils.spec.coffee
+++ b/src/spec/utils.spec.coffee
@@ -1,0 +1,26 @@
+_ = require 'underscore'
+Promise = require 'bluebird'
+
+exports.cleanup = (logger, client) ->
+  logger.debug 'Deleting old inventory entries...'
+  client.inventoryEntries.all().fetch()
+    .then (result) ->
+      Promise.all _.map result.body.results, (e) ->
+        client.inventoryEntries.byId(e.id).delete(e.version)
+    .then (results) ->
+      logger.debug "Inventory #{_.size results} deleted."
+      logger.debug 'Deleting old types entries...'
+      client.types.all().fetch()
+    .then (result) ->
+      Promise.all _.map result.body.results, (e) ->
+        client.types.byId(e.id).delete(e.version)
+    .then (results) ->
+      logger.debug "Types #{_.size results} deleted."
+      logger.debug 'Deleting old channels entries...'
+      client.channels.all().fetch()
+    .then (result) ->
+      Promise.all _.map result.body.results, (e) ->
+        client.channels.byId(e.id).delete(e.version)
+    .then (results) ->
+      logger.debug "Channels #{_.size results} deleted."
+      Promise.resolve()

--- a/src/spec/zeroInventories.spec.coffee
+++ b/src/spec/zeroInventories.spec.coffee
@@ -1,0 +1,122 @@
+_ = require 'underscore'
+{ExtendedLogger} = require 'sphere-node-utils'
+package_json = require '../package.json'
+Config = require '../config'
+StockImport = require '../lib/stockimport'
+{ cleanup } = require './utils.spec'
+
+describe 'zero inventories test', ->
+
+  beforeEach (done) ->
+    @logger = new ExtendedLogger
+      additionalFields:
+        project_key: Config.config.project_key
+      logConfig:
+        name: "#{package_json.name}-#{package_json.version}"
+        streams: [
+          { level: 'info', stream: process.stdout }
+        ]
+    @stockimport = new StockImport @logger,
+      config: Config.config
+      removeZeroInventories: true
+      csvHeaders: 'sku,quantityOnStock'
+      csvDelimiter: ','
+
+    @client = @stockimport.client
+
+    @logger.info 'About to setup...'
+    cleanup(@logger, @client)
+    .then =>
+      done()
+    .catch (err) -> done(err)
+  , 10000 # 10sec
+
+  afterEach (done) ->
+    @logger.info 'About to cleanup...'
+    cleanup(@logger, @client)
+    .then -> done()
+    .catch (err) -> done(err)
+  , 10000 # 10sec
+
+  describe 'create zero inventory', ->
+
+    it 'should ignore creation', (done) ->
+      raw =
+        '''
+        sku,quantityOnStock
+        new-inventory0,0
+        new-inventory1,0
+        '''
+      @stockimport.run(raw, 'CSV')
+        .then =>
+          @stockimport.summaryReport()
+        .then (message) =>
+          expect(message).toBe 'Summary: nothing to do, everything is fine'
+          @client.inventoryEntries.fetch()
+        .then (result) =>
+          expect(result.body.count).toBe 0
+          done()
+        .catch (err) -> done(err)
+    , 5000 # 5sec
+
+  describe 'update to zero inventory', ->
+
+    it 'should remove instead of updating', (done) ->
+      raw =
+        '''
+        sku,quantityOnStock
+        abcd,123
+        '''
+      @stockimport.run(raw, 'CSV')
+      .then =>
+        @stockimport.summaryReport()
+      .then (message) =>
+        expect(message).toBe 'Summary: there were 1 imported stocks (1 were new, 0 were updates and 0 were deletions)'
+
+        raw =
+        '''
+        sku,quantityOnStock
+        abcd,0
+        '''
+        @stockimport.run(raw, 'CSV')
+      .then =>
+        @stockimport.summaryReport()
+      .then (message) =>
+        expect(message).toBe 'Summary: there were 0 imported stocks (0 were new, 0 were updates and 1 were deletions)'
+        @client.inventoryEntries.fetch()
+      .then (result) ->
+        expect(result.body.count).toBe 0
+        done()
+      .catch (err) -> done(err)
+    , 10000 # 10sec
+
+  describe 'remove existing zero inventories', ->
+
+    it 'should remove zero inventories', (done) ->
+      raw =
+        '''
+        sku,quantityOnStock
+        valid-inventory,123
+        zero-inventory0,0
+        zero-inventory1,0
+        '''
+
+      # allow importer to create zero inventories
+      @stockimport.shouldRemoveZeroInventories = false
+
+      @stockimport.run(raw, 'CSV')
+        .then =>
+          @stockimport.shouldRemoveZeroInventories = true
+
+          @stockimport.removeZeroInventories()
+        .then (removedInventoriesCount) =>
+          expect(removedInventoriesCount).toBe(2)
+          @client.inventoryEntries.fetch()
+        .then (result) ->
+          expect(result.body.count).toBe 1
+
+          existingInventory = result.body.results[0]
+          expect(existingInventory.sku).toBe('valid-inventory')
+          done()
+        .catch (err) -> done(err)
+    , 10000 # 10sec


### PR DESCRIPTION
#### Summary
This PR provides a new param (`--removeZeroInventories`) which will remove zero inventories from CTP project.

Resolves #60 

#### Description
When enabled, it will:
 - skip the creation of inventory entry with the zero quantity (field `quantityOnStock`)
 - delete inventory instead of updating it to zero quantity
 - after the import is finished, additionally fetch and delete all inventories with zero quantity

#### Todo

- Tests
    - [ ] Unit
    - [x] Integration
    - [ ] Acceptance
- [ ] Documentation
<!-- Two persons should review a PR, don't forget to assign them. -->
