### PR TITLE
fix: v3.0.4 throws error while installing in yarn workspaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sphere-stock-import",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "node": ">= 8.0.0"
   },
   "scripts": {
-    "preinstall": "npx npm-force-resolutions",
+    "preinstall": "node safe-resolution-check.js",
     "build": "grunt build",
     "test": "grunt test",
     "coverage": "grunt coverage",

--- a/safe-resolution-check.js
+++ b/safe-resolution-check.js
@@ -1,0 +1,5 @@
+const { spawn } = require( 'child_process' );
+
+try {
+    spawn( 'npx', ['npm-force-resolutions']);
+} catch(e) {}


### PR DESCRIPTION
#### Fixed v3.0.4 throws error while installing in yarn workspaces

Created separate script which will run npx with npm-force-resolutions and it error comes then it will go to fallback.

Fixes: #103 
